### PR TITLE
UE-385 :: 1 time review of mui rte upstream prs

### DIFF
--- a/examples/autocomplete-async/index.tsx
+++ b/examples/autocomplete-async/index.tsx
@@ -1,0 +1,124 @@
+import React, { FunctionComponent } from 'react'
+import ListItemText from '@mui/material/ListItemText'
+import ListItemAvatar from '@mui/material/ListItemAvatar'
+import Avatar from '@mui/material/Avatar'
+import MUIRichTextEditor, { TAutocompleteItem } from '../../'
+
+const save = (data: string) => {
+    console.log(data)
+}
+
+type TStaff = {
+    avatar: string
+    name: string
+}
+
+const Staff: FunctionComponent<TStaff> = (props) => {
+    return (
+        <>
+            <ListItemAvatar>
+                <Avatar src={props.avatar}>{props.name.substr(0, 1)}</Avatar>
+            </ListItemAvatar>
+            <ListItemText
+                primary={props.name}
+            />
+        </>
+    )
+}
+
+const emojis: TAutocompleteItem[] = [
+    {
+        keys: ["face", "grin"],
+        value: "😀",
+        content: "😀",
+    },
+    {
+        keys: ["face", "beaming"],
+        value: "😁",
+        content: "😁",
+    },
+    {
+        keys: ["face", "joy"],
+        value: "😂",
+        content: "😂",
+    },
+    {
+        keys: ["face", "grin", "big"],
+        value: "😃",
+        content: "😃",
+    },
+    {
+        keys: ["face", "grin", "smile"],
+        value: "😄",
+        content: "😄",
+    },
+    {
+        keys: ["face", "sweat"],
+        value: "😅",
+        content: "😅",
+    }
+]
+
+const cities: TAutocompleteItem[] = [
+    {
+        keys: ["mexico"],
+        value: "Mexico City",
+        content: "Mexico City",
+    },
+    {
+        keys: ["mexico", "beach"],
+        value: "Cancun",
+        content: "Cancun",
+    },
+    {
+        keys: ["japan", "olympics"],
+        value: "Tokyo",
+        content: "Tokyo",
+    },
+    {
+        keys: ["japan"],
+        value: "Osaka",
+        content: "Osaka",
+    }
+]
+
+const searchUsers = async (query: string): Promise<TAutocompleteItem[]> => {
+    let response = await fetch(`https://reqres.in/api/users?page=${query.length - 2}`);
+    if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+    }
+    const json = await response.json();
+    return json.data!.map((u:any) => {return {
+        keys: [u.email, u.first_name, u.last_name],
+        value: `${u.first_name}`,
+        content: <Staff name={`${u.first_name} ${u.last_name}`} avatar={u.avatar} />,
+    }});
+};
+
+const Autocomplete = () => {
+    return (
+        <MUIRichTextEditor
+            label="Try typing ':grin' or '/mexico'..."
+            onSave={save}
+            autocomplete={{
+                strategies: [
+                    {
+                        items: emojis,
+                        triggerChar: ":"
+                    },
+                    {
+                        items: cities,
+                        triggerChar: "/"
+                    },
+                    {
+                        asyncItems: searchUsers,
+                        triggerChar: "@",
+                        insertSpaceAfter: false
+                    }
+                ]
+            }}
+        />
+    )
+}
+
+export default Autocomplete

--- a/examples/autocomplete/index.tsx
+++ b/examples/autocomplete/index.tsx
@@ -110,6 +110,7 @@ const Autocomplete = () => {
             label="Try typing ':grin' or '/mexico'..."
             onSave={save}
             autocomplete={{
+                minSearchCharCount: 2,
                 strategies: [
                     {
                         items: emojis,

--- a/examples/main.tsx
+++ b/examples/main.tsx
@@ -15,6 +15,7 @@ import AtomicCustomBlock from './atomic-custom-block'
 import KeyBindings from './key-bindings'
 import MaxLength from './max-length'
 import Autocomplete from './autocomplete'
+import AutocompleteAsync from './autocomplete-async'
 import AutocompleteAtomic from './autocomplete-atomic'
 import AsyncImageUpload from './async-image-upload'
 import AsyncAtomicCustomBlock from './async-atomic-custom-block'
@@ -51,6 +52,7 @@ const App = () => {
                 <button onClick={() => setSample(<KeyBindings />)}>Key Bindings</button>
                 <button onClick={() => setSample(<MaxLength />)}>Max length</button>
                 <button onClick={() => setSample(<Autocomplete />)}>Autocomplete</button>
+                <button onClick={() => setSample(<AutocompleteAsync />)}>AutocompleteAsync</button>
                 <button onClick={() => setSample(<AutocompleteAtomic />)}>Autocomplete Atomic</button>
                 <div style={{
                     margin: "20px 0"

--- a/index.d.ts
+++ b/index.d.ts
@@ -87,6 +87,7 @@ export declare type TAutocompleteStrategy = {
     atomicBlockName?: string;
 };
 export declare type TAutocomplete = {
+    minSearchCharCount?: number;
     strategies: TAutocompleteStrategy[];
     suggestLimit?: number;
 };

--- a/index.d.ts
+++ b/index.d.ts
@@ -81,8 +81,9 @@ export declare type TDecorator = {
     regex: RegExp;
 };
 export declare type TAutocompleteStrategy = {
+    asyncItems?: (search: string) => Promise<TAutocompleteItem[]>
     triggerChar: string;
-    items: TAutocompleteItem[];
+    items?: TAutocompleteItem[];
     insertSpaceAfter?: boolean;
     atomicBlockName?: string;
 };
@@ -97,6 +98,7 @@ export declare type TAsyncAtomicBlockResponse = {
 export declare type TMUIRichTextEditorRef = {
     focus: () => void;
     save: () => void;
+    insertText: (text: string) => void;
     /**
      * @deprecated Use `insertAtomicBlockSync` instead.
      */

--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-export {default} from './dist/MUIRichTextEditor'
+module.exports = require('./dist/MUIRichTextEditor')

--- a/src/MUIRichTextEditor.tsx
+++ b/src/MUIRichTextEditor.tsx
@@ -146,12 +146,7 @@ const styles = (theme: Theme & TMUIRichTextEditorStyles) => createStyles({
     inheritFontSize: theme?.overrides?.MUIRichTextEditor?.inheritFontSize || {
         fontSize: "inherit"
     },
-    editor: theme?.overrides?.MUIRichTextEditor?.editor || {},
-    editorContainer: theme?.overrides?.MUIRichTextEditor?.editorContainer || {
-        margin: theme.spacing(1, 0, 0, 0),
-        cursor: "text",
-        width: "100%",
-        padding: theme.spacing(0, 0, 1, 0),
+    editor: theme?.overrides?.MUIRichTextEditor?.editor || {
         '& .public-DraftStyleDefault-ltr': {direction: 'ltr', textAlign: 'left'},
         '& .public-DraftStyleDefault-rtl': {direction :'rtl', textAlign: 'right'},
         '& .public-DraftStyleDefault-listLTR': {direction: 'ltr'},
@@ -169,6 +164,12 @@ const styles = (theme: Theme & TMUIRichTextEditorStyles) => createStyles({
         '& .public-DraftStyleDefault-unorderedListItem': {listStyleType: 'square', position: 'relative'},
         '& .public-DraftStyleDefault-unorderedListItem.public-DraftStyleDefault-depth0': {listStyleType: 'disc'},
         '& .public-DraftStyleDefault-unorderedListItem.public-DraftStyleDefault-depth1': {listStyleType: 'circle'}
+    },
+    editorContainer: theme?.overrides?.MUIRichTextEditor?.editorContainer || {
+        margin: theme.spacing(1, 0, 0, 0),
+        cursor: "text",
+        width: "100%",
+        padding: theme.spacing(0, 0, 1, 0)
     },
     editorReadOnly: theme?.overrides?.MUIRichTextEditor?.editorReadOnly || {
         borderBottom: "none"

--- a/src/MUIRichTextEditor.tsx
+++ b/src/MUIRichTextEditor.tsx
@@ -1143,6 +1143,7 @@ const MUIRichTextEditor: ForwardRefRenderFunction<TMUIRichTextEditorRef, IMUIRic
                         data={state.urlData}
                         anchor={state.anchorUrlPopover}
                         onConfirm={handleConfirmPrompt}
+                        onCancel={dismissPopover}
                         isMedia={state.urlIsMedia}
                     />
                     : null}

--- a/src/MUIRichTextEditor.tsx
+++ b/src/MUIRichTextEditor.tsx
@@ -35,6 +35,7 @@ export type TAutocompleteStrategy = {
 }
 
 export type TAutocomplete = {
+    minSearchCharCount?: number;
     strategies: TAutocompleteStrategy[]
     suggestLimit?: number
 }
@@ -201,7 +202,6 @@ const styleRenderMap: DraftStyleMap = {
 }
 
 const { hasCommandModifier } = KeyBindingUtil
-const autocompleteMinSearchCharCount = 2
 const lineHeight = 26
 const defaultInlineToolbarControls = ["bold", "italic", "underline", "clear"]
 
@@ -267,6 +267,7 @@ const MUIRichTextEditor: ForwardRefRenderFunction<TMUIRichTextEditorRef, IMUIRic
     const autocompleteSelectionStateRef = useRef<SelectionState | undefined>(undefined)
     const autocompletePositionRef = useRef<TPosition | undefined>(undefined)
     const autocompleteLimit = props.autocomplete ? props.autocomplete.suggestLimit || 5 : 5
+    const autocompleteMinSearchCharCount =  props?.autocomplete?.minSearchCharCount ?? 2;
     const isFirstFocus = useRef(true)
     const customBlockMapRef = useRef<DraftBlockRenderMap | undefined>(undefined)
     const customStyleMapRef = useRef<DraftStyleMap | undefined>(undefined)

--- a/src/MUIRichTextEditor.tsx
+++ b/src/MUIRichTextEditor.tsx
@@ -132,6 +132,41 @@ interface TMUIRichTextEditorStyles {
     }
 }
 
+// styling for multilevel (tabbed) lists from draft-js
+const listStyles = {
+    '& .public-DraftStyleDefault-ol,.public-DraftStyleDefault-ul': {margin: '16px 0', padding: 0},
+    '& .public-DraftStyleDefault-ltr': {direction: 'ltr', textAlign: 'left'},
+    '& .public-DraftStyleDefault-rtl': {direction :'rtl', textAlign: 'right'},
+    '& .public-DraftStyleDefault-listLTR': {direction: 'ltr'},
+    '& .public-DraftStyleDefault-listRTL': {direction: 'rtl'},
+    '& .public-DraftStyleDefault-depth0.public-DraftStyleDefault-listLTR': {marginLeft: '1.5em'},
+    '& .public-DraftStyleDefault-depth1.public-DraftStyleDefault-listLTR': {marginLeft: '3em'},
+    '& .public-DraftStyleDefault-depth2.public-DraftStyleDefault-listLTR': {marginLeft: '4.5em'},
+    '& .public-DraftStyleDefault-depth3.public-DraftStyleDefault-listLTR': {marginLeft: '6em'},
+    '& .public-DraftStyleDefault-depth4.public-DraftStyleDefault-listLTR': {marginLeft: '7.5em'},
+    '& .public-DraftStyleDefault-depth0.public-DraftStyleDefault-listRTL': {marginRight: '1.5em'},
+    '& .public-DraftStyleDefault-depth1.public-DraftStyleDefault-listRTL': {marginRight: '3em'},
+    '& .public-DraftStyleDefault-depth2.public-DraftStyleDefault-listRTL': {marginRight: '4.5em'},
+    '& .public-DraftStyleDefault-depth3.public-DraftStyleDefault-listRTL': {marginRight: '6em'},
+    '& .public-DraftStyleDefault-depth4.public-DraftStyleDefault-listRTL': {marginRight: '7.5em'},
+    '& .public-DraftStyleDefault-unorderedListItem': {listStyleType: 'square', position: 'relative'},
+    '& .public-DraftStyleDefault-unorderedListItem.public-DraftStyleDefault-depth0': {listStyleType: 'disc'},
+    '& .public-DraftStyleDefault-unorderedListItem.public-DraftStyleDefault-depth1': {listStyleType: 'circle'},
+    '& .public-DraftStyleDefault-orderedListItem': {listStyleType: 'none', position: 'relative'},
+    '& .public-DraftStyleDefault-orderedListItem.public-DraftStyleDefault-listLTR:before': {left: '-36px', position: 'absolute', textAlign: 'right', width: '30px'},
+    '& .public-DraftStyleDefault-orderedListItem.public-DraftStyleDefault-listRTL:before': {position: 'absolute', right: '-36px', textAlign: 'left', width: '30px'},
+    '& .public-DraftStyleDefault-orderedListItem:before': {content: 'counter(ol0) ". "', counterIncrement: 'ol0'},
+    '& .public-DraftStyleDefault-orderedListItem.public-DraftStyleDefault-depth1:before': {content: 'counter(ol1,lower-alpha) ". "', counterIncrement: 'ol1'},
+    '& .public-DraftStyleDefault-orderedListItem.public-DraftStyleDefault-depth2:before': {content: 'counter(ol2,lower-roman) ". "', counterIncrement: 'ol2'},
+    '& .public-DraftStyleDefault-orderedListItem.public-DraftStyleDefault-depth3:before': {content: 'counter(ol3) ". "', counterIncrement: 'ol3'},
+    '& .public-DraftStyleDefault-orderedListItem.public-DraftStyleDefault-depth4:before': {content: 'counter(ol4,lower-alpha) ". "', counterIncrement: 'ol4'},
+    '& .public-DraftStyleDefault-depth0.public-DraftStyleDefault-reset': {counterReset: 'ol0'},
+    '& .public-DraftStyleDefault-depth1.public-DraftStyleDefault-reset': {counterReset: 'ol1'},
+    '& .public-DraftStyleDefault-depth2.public-DraftStyleDefault-reset': {counterReset: 'ol2'},
+    '& .public-DraftStyleDefault-depth3.public-DraftStyleDefault-reset': {counterReset: 'ol3'},
+    '& .public-DraftStyleDefault-depth4.public-DraftStyleDefault-reset': {counterReset: 'ol4'},
+}
+
 const styles = (theme: Theme & TMUIRichTextEditorStyles) => createStyles({
     root: theme?.overrides?.MUIRichTextEditor?.root || {},
     container: theme?.overrides?.MUIRichTextEditor?.container || {
@@ -147,23 +182,7 @@ const styles = (theme: Theme & TMUIRichTextEditorStyles) => createStyles({
         fontSize: "inherit"
     },
     editor: theme?.overrides?.MUIRichTextEditor?.editor || {
-        '& .public-DraftStyleDefault-ltr': {direction: 'ltr', textAlign: 'left'},
-        '& .public-DraftStyleDefault-rtl': {direction :'rtl', textAlign: 'right'},
-        '& .public-DraftStyleDefault-listLTR': {direction: 'ltr'},
-        '& .public-DraftStyleDefault-listRTL': {direction: 'rtl'},
-        '& .public-DraftStyleDefault-depth0.public-DraftStyleDefault-listLTR': {marginLeft: '1.5em'},
-        '& .public-DraftStyleDefault-depth1.public-DraftStyleDefault-listLTR': {marginLeft: '3em'},
-        '& .public-DraftStyleDefault-depth2.public-DraftStyleDefault-listLTR': {marginLeft: '4.5em'},
-        '& .public-DraftStyleDefault-depth3.public-DraftStyleDefault-listLTR': {marginLeft: '6em'},
-        '& .public-DraftStyleDefault-depth4.public-DraftStyleDefault-listLTR': {marginLeft: '7.5em'},
-        '& .public-DraftStyleDefault-depth0.public-DraftStyleDefault-listRTL': {marginRight: '1.5em'},
-        '& .public-DraftStyleDefault-depth1.public-DraftStyleDefault-listRTL': {marginRight: '3em'},
-        '& .public-DraftStyleDefault-depth2.public-DraftStyleDefault-listRTL': {marginRight: '4.5em'},
-        '& .public-DraftStyleDefault-depth3.public-DraftStyleDefault-listRTL': {marginRight: '6em'},
-        '& .public-DraftStyleDefault-depth4.public-DraftStyleDefault-listRTL': {marginRight: '7.5em'},
-        '& .public-DraftStyleDefault-unorderedListItem': {listStyleType: 'square', position: 'relative'},
-        '& .public-DraftStyleDefault-unorderedListItem.public-DraftStyleDefault-depth0': {listStyleType: 'disc'},
-        '& .public-DraftStyleDefault-unorderedListItem.public-DraftStyleDefault-depth1': {listStyleType: 'circle'}
+        ...listStyles
     },
     editorContainer: theme?.overrides?.MUIRichTextEditor?.editorContainer || {
         margin: theme.spacing(1, 0, 0, 0),

--- a/src/MUIRichTextEditor.tsx
+++ b/src/MUIRichTextEditor.tsx
@@ -151,7 +151,24 @@ const styles = (theme: Theme & TMUIRichTextEditorStyles) => createStyles({
         margin: theme.spacing(1, 0, 0, 0),
         cursor: "text",
         width: "100%",
-        padding: theme.spacing(0, 0, 1, 0)
+        padding: theme.spacing(0, 0, 1, 0),
+        '& .public-DraftStyleDefault-ltr': {direction: 'ltr', textAlign: 'left'},
+        '& .public-DraftStyleDefault-rtl': {direction :'rtl', textAlign: 'right'},
+        '& .public-DraftStyleDefault-listLTR': {direction: 'ltr'},
+        '& .public-DraftStyleDefault-listRTL': {direction: 'rtl'},
+        '& .public-DraftStyleDefault-depth0.public-DraftStyleDefault-listLTR': {marginLeft: '1.5em'},
+        '& .public-DraftStyleDefault-depth1.public-DraftStyleDefault-listLTR': {marginLeft: '3em'},
+        '& .public-DraftStyleDefault-depth2.public-DraftStyleDefault-listLTR': {marginLeft: '4.5em'},
+        '& .public-DraftStyleDefault-depth3.public-DraftStyleDefault-listLTR': {marginLeft: '6em'},
+        '& .public-DraftStyleDefault-depth4.public-DraftStyleDefault-listLTR': {marginLeft: '7.5em'},
+        '& .public-DraftStyleDefault-depth0.public-DraftStyleDefault-listRTL': {marginRight: '1.5em'},
+        '& .public-DraftStyleDefault-depth1.public-DraftStyleDefault-listRTL': {marginRight: '3em'},
+        '& .public-DraftStyleDefault-depth2.public-DraftStyleDefault-listRTL': {marginRight: '4.5em'},
+        '& .public-DraftStyleDefault-depth3.public-DraftStyleDefault-listRTL': {marginRight: '6em'},
+        '& .public-DraftStyleDefault-depth4.public-DraftStyleDefault-listRTL': {marginRight: '7.5em'},
+        '& .public-DraftStyleDefault-unorderedListItem': {listStyleType: 'square', position: 'relative'},
+        '& .public-DraftStyleDefault-unorderedListItem.public-DraftStyleDefault-depth0': {listStyleType: 'disc'},
+        '& .public-DraftStyleDefault-unorderedListItem.public-DraftStyleDefault-depth1': {listStyleType: 'circle'}
     },
     editorReadOnly: theme?.overrides?.MUIRichTextEditor?.editorReadOnly || {
         borderBottom: "none"
@@ -665,6 +682,11 @@ const MUIRichTextEditor: ForwardRefRenderFunction<TMUIRichTextEditorRef, IMUIRic
         return "not-handled"
     }
 
+    const onTab = (event: any) => {
+        const maxDepth = 4;
+        handleChange(RichUtils.onTab(event, editorState, maxDepth));
+    };
+
     const handleCustomClick = (style: any, id: string) => {
         if (!props.customControls) {
             return
@@ -1152,6 +1174,7 @@ const MUIRichTextEditor: ForwardRefRenderFunction<TMUIRichTextEditorRef, IMUIRic
                             editorState={editorState}
                             onChange={handleChange}
                             onFocus={handleEditorFocus}
+                            onTab={onTab}
                             readOnly={props.readOnly}
                             handleKeyCommand={handleKeyCommand}
                             handleBeforeInput={handleBeforeInput}

--- a/src/components/ToolbarButton.tsx
+++ b/src/components/ToolbarButton.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from 'react'
-import IconButton from '@mui/material/IconButton'
+import {IconButton, Tooltip} from '@mui/material'
 import { TToolbarComponentProps, TToolbarButtonSize } from './Toolbar'
 
 interface IToolbarButtonProps {
@@ -34,6 +34,8 @@ const ToolbarButton: FunctionComponent<IToolbarButtonProps> = (props) => {
     }
     if (props.icon) {
         return (
+            <Tooltip title={props.label}>
+
             <IconButton
                 {...sharedProps}
                 aria-label={props.label}
@@ -42,6 +44,7 @@ const ToolbarButton: FunctionComponent<IToolbarButtonProps> = (props) => {
             >
                 {props.icon}
             </IconButton>
+            </Tooltip>
         )
     }
     if (props.component) {

--- a/src/components/ToolbarButton.tsx
+++ b/src/components/ToolbarButton.tsx
@@ -35,15 +35,14 @@ const ToolbarButton: FunctionComponent<IToolbarButtonProps> = (props) => {
     if (props.icon) {
         return (
             <Tooltip title={props.label}>
-
-            <IconButton
-                {...sharedProps}
-                aria-label={props.label}
-                color={props.active ? "primary" : "default"}
-                size={size}
-            >
-                {props.icon}
-            </IconButton>
+                <IconButton
+                    {...sharedProps}
+                    aria-label={props.label}
+                    color={props.active ? "primary" : "default"}
+                    size={size}
+                >
+                    {props.icon}
+                </IconButton>
             </Tooltip>
         )
     }

--- a/src/components/UrlPopover.tsx
+++ b/src/components/UrlPopover.tsx
@@ -31,6 +31,7 @@ interface IUrlPopoverStateProps extends WithStyles<typeof styles> {
     data?: TUrlData
     isMedia?: boolean
     onConfirm: (isMedia?: boolean, ...args: any) => void
+    onCancel: () => void
 }
 
 const styles = ({ spacing }: Theme) => createStyles({
@@ -69,6 +70,7 @@ const UrlPopover: FunctionComponent<IUrlPopoverStateProps> = (props) => {
     return (
         <Popover
             open={props.anchor !== undefined}
+            onClose={props.onCancel}
             anchorEl={props.anchor}
             anchorOrigin={{
                 vertical: "bottom",


### PR DESCRIPTION
[UE-385](https://tetra.atlassian.net/browse/UE-385)  

Of the 8 PRs listed in the ticket, only [Add an example of Material UI TextField integration by steurt · Pull Request #131 · niuware/mui-rte](https://github.com/niuware/mui-rte/pull/131) didn't make it in. It was very buggy. I got through two or three bugs and more kept presenting. 

Additionally, the implementation of [Added multilevel Lists by DMOEdetc · Pull Request #262 · niuware/mui-rte](https://github.com/niuware/mui-rte/pull/262) is limited. The logic in this PR in minimal, and styling is needed to render the multilevel (tabbed) lists correctly. draft-js (which this is built on) provides styling up to lists of depth 4, and I basically copied that styling over. I tried to find a way to programmatically apply these styles as needed, but couldn't find a reliable way. It's redundant, and ultimately limited, but we can always add more styling for additional list depth.